### PR TITLE
세션 카드에 요청 처리 시간 및 총 작업 시간 표시

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,97 @@
+# PROJECT KNOWLEDGE BASE
+
+**Generated:** 2026-03-17
+**Commit:** 794fcb9
+**Branch:** fix/subagent-stale-list
+
+## OVERVIEW
+
+Real-time OpenCode session monitoring dashboard. Bun single-server (TypeScript + SQLite) with SSE push to a vanilla SPA frontend. Zero external framework dependencies.
+
+## STRUCTURE
+
+```
+oc-dashboard/
+├── server.ts      # HTTP server, SSE broadcast, state aggregation, demo mode
+├── db.ts          # All SQLite queries — readonly access to OpenCode's DB
+├── process.ts     # macOS-only process detection (ps aux + lsof)
+├── plugin/        # OpenCode plugin — writes active-sessions.json on session events
+│   └── index.ts
+├── public/
+│   └── index.html # Entire frontend: HTML + CSS + JS in single file (1209 lines)
+├── tests/
+│   ├── helpers.ts      # Test DB factory (in-memory + file-based)
+│   ├── db.test.ts      # DB layer unit tests (490 lines)
+│   ├── server.test.ts  # HTTP endpoint tests
+│   └── e2e.test.ts     # Playwright browser tests
+└── data.db        # Local SQLite (gitignored, not OpenCode's DB)
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+|------|----------|-------|
+| Add new data source | `db.ts` | Follow `batchGet*` pattern with `openDb()` per call |
+| New API endpoint | `server.ts` → `Bun.serve.fetch()` | URL routing is manual string matching |
+| Frontend changes | `public/index.html` | Single-file SPA, all JS inline in `<script>` |
+| Session status logic | `server.ts` → `buildState()` | Merges plugin file + process detection + DB |
+| Status classification | `db.ts` → `classifyStatus()` | ACTIVE <10s, RECENT <5min, IDLE >5min |
+| Plugin behavior | `plugin/index.ts` | Writes `~/.local/share/opencode/active-sessions.json` |
+| Process detection | `process.ts` | macOS-only: `ps aux` → filter `opencode` → `lsof` for cwd |
+| Test setup | `tests/helpers.ts` | `createTestDbFile()` returns tmp DB + cleanup fn |
+| Demo mode | `server.ts` → `buildDemoState()` | `DEMO=true bun run server.ts` for mock data |
+
+## CONVENTIONS
+
+- **DB access**: Open → query → close per function call. No connection pooling. Always `readonly: true`.
+- **Batch queries**: `batchGet*(sessionIds: string[])` with `IN (${placeholders})` pattern. Return `Record<string, T>`.
+- **Error handling**: `try/catch` → `console.warn("[module]", err)` → return empty default (never throw to caller).
+- **Types**: Interfaces exported from `db.ts`. DB columns are `snake_case`, TS properties are `camelCase`.
+- **Frontend**: No build step, no framework. Raw DOM manipulation. SSE via `EventSource`. All in one HTML file.
+- **Naming**: Files are `kebab-case.ts`. Korean commit messages. Types use `interface` (not `type`).
+- **Tests**: `bun:test` with `describe/test/expect`. DB tests override `process.env.DB_PATH` with temp file.
+
+## ANTI-PATTERNS (THIS PROJECT)
+
+- **NEVER** use connection pooling or keep DB handles open — `openDb()` per function is intentional (OpenCode's DB is shared)
+- **NEVER** add frontend build tooling (webpack, vite, etc.) — zero-dependency SPA is a design choice
+- **NEVER** add npm dependencies to root `package.json` unless absolutely unavoidable (playwright is for tests only)
+- **NEVER** assume Linux — process detection uses macOS-specific `lsof -p PID -a -d cwd -Fn`
+- **NEVER** write to OpenCode's DB — all DB access is `readonly: true`
+- **NEVER** use `as any` or `@ts-ignore` — strict mode is enforced
+- **AVOID** splitting `public/index.html` — the single-file approach is deliberate for zero-build deployment
+
+## UNIQUE STYLES
+
+- **Plugin architecture**: Symlinked into `~/.config/opencode/plugins/`. Communicates via JSON file, not IPC.
+- **Dual detection**: Session activity detected via plugin file (primary) OR process detection (fallback).
+- **Dismiss pattern**: In-memory `Set<string>` for dismissed sessions — not persisted, resets on restart.
+- **Caching**: `projectsCache` with 30s TTL. Sessions are always fresh.
+- **SSE**: 2s polling interval. Broadcast skipped when `clients.size === 0`.
+- **Demo mode**: `DEMO=true` env var serves hardcoded mock data — useful for development without OpenCode running.
+
+## COMMANDS
+
+```bash
+# Dev
+bun run server.ts                    # Start server (port 3333)
+PORT=8080 bun run server.ts          # Custom port
+DEMO=true bun run server.ts          # Demo mode with mock data
+DB_PATH=/path/to/db bun run server.ts  # Custom OpenCode DB path
+
+# Test
+bun test                             # All tests
+bun test tests/db.test.ts            # DB tests only
+
+# Plugin install
+ln -s "$(pwd)/plugin/index.ts" ~/.config/opencode/plugins/oc-dashboard-plugin.ts
+```
+
+## NOTES
+
+- `data.db` in root is a local artifact, not OpenCode's DB. OpenCode's DB defaults to `~/.local/share/opencode/opencode.db`.
+- `plugin/` has its own `package.json` and `node_modules/` — it's a separate package for the `@opencode-ai/plugin` type.
+- `batchGetPendingBackgroundTasks()` in `db.ts` is the most complex query (~40 lines) — parses `bg_` task IDs from tool output JSON.
+- Frontend uses CSS Grid layout with sidebar (240px) + main area. Dark theme only (GitHub-inspired palette).
+- Archive threshold: sessions inactive >3 days are moved to archived view.
+- `Bun` type is declared locally in `server.ts` (lines 28-32) — not from `bun-types`.

--- a/db.ts
+++ b/db.ts
@@ -51,6 +51,12 @@ export interface TokenSummary {
   totalOutput: number;
 }
 
+export interface SessionTiming {
+  firstUserRequestAt: number;
+  lastUserRequestAt: number;
+  responseEndAt: number | null;
+}
+
 function openDb(): Database {
   const dbPath =
     process.env.DB_PATH ??
@@ -472,6 +478,85 @@ export function batchGetPendingBackgroundTasks(
   } catch (err) {
     console.warn("[db] batchGetPendingBackgroundTasks error:", err);
     return new Set();
+  }
+}
+
+export function batchGetSessionTiming(
+  sessionIds: string[],
+): Record<string, SessionTiming> {
+  if (sessionIds.length === 0) return {};
+  try {
+    const db = openDb();
+    try {
+      const placeholders = sessionIds.map(() => "?").join(",");
+      const rows = db
+        .query<
+          {
+            session_id: string;
+            firstUserRequestAt: number;
+            lastUserRequestAt: number;
+            responseEndAt: number | null;
+          },
+          string[]
+        >(
+          `WITH real_user AS (
+             SELECT m.session_id, m.time_created
+             FROM message m
+             WHERE m.session_id IN (${placeholders})
+               AND json_extract(m.data, '$.role') = 'user'
+               AND EXISTS (
+                 SELECT 1
+                 FROM part p
+                 WHERE p.message_id = m.id
+                   AND json_extract(p.data, '$.type') = 'text'
+                   AND ltrim(COALESCE(json_extract(p.data, '$.text'), '')) NOT LIKE '<system-reminder>%'
+               )
+           ),
+           first_last AS (
+             SELECT
+               session_id,
+               MIN(time_created) AS first_user_time,
+               MAX(time_created) AS last_user_time
+             FROM real_user
+             GROUP BY session_id
+           ),
+           response_end AS (
+             SELECT
+               fl.session_id,
+               MAX(p.time_created) AS response_end_time
+             FROM first_last fl
+             LEFT JOIN message m
+               ON m.session_id = fl.session_id
+              AND json_extract(m.data, '$.role') = 'assistant'
+              AND m.time_created >= fl.last_user_time
+             LEFT JOIN part p ON p.message_id = m.id
+             GROUP BY fl.session_id
+           )
+           SELECT
+             fl.session_id,
+             fl.first_user_time AS firstUserRequestAt,
+             fl.last_user_time AS lastUserRequestAt,
+             re.response_end_time AS responseEndAt
+           FROM first_last fl
+           LEFT JOIN response_end re ON re.session_id = fl.session_id`,
+        )
+        .all(...sessionIds);
+
+      const result: Record<string, SessionTiming> = {};
+      for (const r of rows) {
+        result[r.session_id] = {
+          firstUserRequestAt: r.firstUserRequestAt,
+          lastUserRequestAt: r.lastUserRequestAt,
+          responseEndAt: r.responseEndAt,
+        };
+      }
+      return result;
+    } finally {
+      db.close();
+    }
+  } catch (err) {
+    console.warn("[db] batchGetSessionTiming error:", err);
+    return {};
   }
 }
 

--- a/db.ts
+++ b/db.ts
@@ -509,7 +509,7 @@ export function batchGetSessionTiming(
                  FROM part p
                  WHERE p.message_id = m.id
                    AND json_extract(p.data, '$.type') = 'text'
-                   AND ltrim(COALESCE(json_extract(p.data, '$.text'), '')) NOT LIKE '<system-reminder>%'
+                   AND ltrim(COALESCE(json_extract(p.data, '$.text'), ''), ' ' || char(10) || char(13) || char(9)) NOT LIKE '<system-reminder>%'
                )
            ),
            first_last AS (

--- a/public/index.html
+++ b/public/index.html
@@ -866,6 +866,25 @@
       return d + 'd ago';
     }
 
+    function formatDuration(ms) {
+      if (ms == null || ms < 0) return '';
+      const sec = Math.floor(ms / 1000);
+      if (sec < 60) return sec + 's';
+      const min = Math.floor(sec / 60);
+      if (min < 60) {
+        const remSec = sec % 60;
+        return remSec > 0 ? `${min}m ${remSec}s` : `${min}m`;
+      }
+      const hr = Math.floor(min / 60);
+      if (hr < 24) {
+        const remMin = min % 60;
+        return remMin > 0 ? `${hr}h ${remMin}m` : `${hr}h`;
+      }
+      const d = Math.floor(hr / 24);
+      const remHr = hr % 24;
+      return remHr > 0 ? `${d}d ${remHr}h` : `${d}d`;
+    }
+
     function render(data) {
       lastData = data;
       renderSidebar(data);
@@ -904,6 +923,7 @@
       const todos = data.todos || {};
       const messages = data.messages || {};
       const tokens = data.sessionTokens || {};
+      const timings = data.sessionTimings || {};
       const agents = data.sessionAgents || {};
       const waitingSet = new Set(data.waitingSessions || []);
       const delegatingSet = new Set(data.delegatingSessions || []);
@@ -927,9 +947,9 @@
           return;
         }
 
-        const activeHtml = sorted.map(s => renderSessionCard(s, todos[s.id] || [], messages[s.id], projMap[s.projectId], false, tokens[s.id], agents[s.id], waitingSet.has(s.id), delegatingSet.has(s.id))).join('');
+        const activeHtml = sorted.map(s => renderSessionCard(s, todos[s.id] || [], messages[s.id], projMap[s.projectId], false, tokens[s.id], timings[s.id], agents[s.id], waitingSet.has(s.id), delegatingSet.has(s.id))).join('');
         const archivedHtml = showArchivedSessions
-          ? archivedSorted.map(s => renderSessionCard(s, [], null, projMap[s.projectId], true, tokens[s.id], agents[s.id], false, false)).join('')
+          ? archivedSorted.map(s => renderSessionCard(s, [], null, projMap[s.projectId], true, tokens[s.id], timings[s.id], agents[s.id], false, false)).join('')
           : '';
 
         container.innerHTML = activeHtml + renderArchiveToggle(archivedSorted.length) + archivedHtml;
@@ -953,7 +973,7 @@
           const total = projArchived.length;
           const archivedHtml = total === 0
             ? '<div class="empty-state">No sessions</div>'
-            : projArchived.map(s => renderSessionCard(s, [], null, null, true, tokens[s.id], agents[s.id], false, false)).join('');
+            : projArchived.map(s => renderSessionCard(s, [], null, null, true, tokens[s.id], timings[s.id], agents[s.id], false, false)).join('');
           return `
             <div class="main-header">
               <span class="main-title">${escHtml(proj.displayName)}</span>
@@ -966,9 +986,9 @@
         const sessionCount = projSessions.length;
         const sessionHtml = sessionCount === 0
           ? '<div class="empty-state">No active sessions</div>'
-          : projSessions.map(s => renderSessionCard(s, todos[s.id] || [], messages[s.id], null, false, tokens[s.id], agents[s.id], waitingSet.has(s.id), delegatingSet.has(s.id))).join('');
+          : projSessions.map(s => renderSessionCard(s, todos[s.id] || [], messages[s.id], null, false, tokens[s.id], timings[s.id], agents[s.id], waitingSet.has(s.id), delegatingSet.has(s.id))).join('');
         const archivedHtml = showArchivedSessions
-          ? projArchived.map(s => renderSessionCard(s, [], null, null, true, tokens[s.id], agents[s.id], false, false)).join('')
+          ? projArchived.map(s => renderSessionCard(s, [], null, null, true, tokens[s.id], timings[s.id], agents[s.id], false, false)).join('')
           : '';
         return `
           <div class="main-header">
@@ -993,7 +1013,7 @@
       if (notif) { notif.close(); activeNotifications.delete(sessionId); }
     }
 
-    function renderSessionCard(session, todos, msgData, projectName, isArchived = false, tokenData = null, agentName = null, isWaiting = false, isDelegating = false) {
+    function renderSessionCard(session, todos, msgData, projectName, isArchived = false, tokenData = null, timingData = null, agentName = null, isWaiting = false, isDelegating = false) {
       const statusClass = isWaiting ? 'waiting' : isDelegating ? 'delegating' : session.status.toLowerCase();
       const progressHtml = renderCircularProgress(todos, session.status);
 
@@ -1023,6 +1043,30 @@
 
       const timeHtml = session.timeUpdated
         ? `<span style="color:var(--text-muted);font-size:11px;margin-right:8px">${relativeTime(session.timeUpdated)}</span>`
+        : '';
+
+      const now = Date.now();
+      const totalWorkMs = timingData?.firstUserRequestAt
+        ? Math.max(0, (session.timeUpdated || now) - timingData.firstUserRequestAt)
+        : null;
+      const isLive = !isArchived && (statusClass === 'active' || statusClass === 'waiting' || statusClass === 'delegating');
+      let reqLabel = '';
+      let reqMs = null;
+      if (timingData?.lastUserRequestAt) {
+        if (isLive) {
+          reqMs = Math.max(0, now - timingData.lastUserRequestAt);
+          reqLabel = 'Elapsed';
+        } else if (timingData.responseEndAt) {
+          reqMs = Math.max(0, timingData.responseEndAt - timingData.lastUserRequestAt);
+          reqLabel = 'Took';
+        }
+      }
+
+      const timingHtml = (reqMs != null || totalWorkMs != null)
+        ? `<div style="display:flex;justify-content:flex-end;gap:8px;margin-top:6px;font-size:10px;color:var(--text-muted)">
+             ${reqMs != null ? `<span>${reqLabel} ${formatDuration(reqMs)}</span>` : ''}
+             ${totalWorkMs != null ? `<span>Total ${formatDuration(totalWorkMs)}</span>` : ''}
+           </div>`
         : '';
 
       // git diff (null-safe: 모두 null이거나 0이면 미렌더링)
@@ -1089,6 +1133,7 @@
                 ${tokenData ? `<span style="color:var(--text-muted);font-size:11px">↑${formatNumber(tokenData.totalInput)}&emsp;↓${formatNumber(tokenData.totalOutput)}</span><span style="color:var(--card-border);font-size:11px;margin:0 4px">|</span>` : ''}${timeHtml}
                 <span class="status-badge ${statusClass}">${escHtml(displayStatus)}</span>
               </div>
+              ${timingHtml}
               ${progressHtml}
             </div>
           </div>

--- a/public/index.html
+++ b/public/index.html
@@ -678,6 +678,7 @@
     const activeNotifications = new Map();
     const expandedSubAgents = new Set(); // sessionId — expanded sub-agent list
     const subAgentCache = new Map();     // sessionId -> SubAgentSession[]
+    const loadingSubAgents = new Set();  // sessionId — in-flight fetch guard
     let lastData = null; // 최신 SSE 데이터 보관 (toggleSubAgents에서 즉시 재렌더용)
     let selectedProjectId = 'all';
     let showArchivedSessions = false;
@@ -1191,6 +1192,8 @@
     }
 
     async function fetchSubAgents(sessionId) {
+      if (loadingSubAgents.has(sessionId)) return; // 중복 호출 차단
+      loadingSubAgents.add(sessionId);
       try {
         const res = await fetch(`/sessions/${sessionId}/subagents`);
         if (!res.ok) return;
@@ -1211,6 +1214,8 @@
         }
       } catch (e) {
         console.warn('[dashboard] fetchSubAgents error:', e);
+      } finally {
+        loadingSubAgents.delete(sessionId);
       }
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -683,6 +683,8 @@
     let showArchivedSessions = false;
     let showArchivedProjects = false;
 
+    setInterval(() => { if (lastData) render(lastData); }, 1_000);
+
     function formatNumber(n) {
       if (n == null || isNaN(n)) return '0';
       if (n >= 1_000_000) return (n / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'M';

--- a/server.ts
+++ b/server.ts
@@ -6,11 +6,21 @@ import {
   getSubAgentCounts,
   getSubAgentSessions,
   batchGetTokenSummary,
+  batchGetSessionTiming,
   batchGetSessionAgents,
   batchGetPendingQuestions,
   batchGetPendingBackgroundTasks,
 } from "./db";
-import type { Project, Session, Todo, MessagePreview, SessionMessages, SubAgentSession, TokenSummary } from "./db";
+import type {
+  Project,
+  Session,
+  Todo,
+  MessagePreview,
+  SessionMessages,
+  SubAgentSession,
+  TokenSummary,
+  SessionTiming,
+} from "./db";
 import { getOpenCodeProcesses, type OcProcess } from "./process";
 
 const ACTIVE_SESSIONS_PATH = `${Bun.env.HOME || ""}/.local/share/opencode/active-sessions.json`;
@@ -55,6 +65,7 @@ interface DashboardState {
   processes: OcProcess[];
   transitions: Transition[];
   sessionTokens: Record<string, TokenSummary>;
+  sessionTimings: Record<string, SessionTiming>;
   sessionAgents: Record<string, string>;
   waitingSessions: string[];
   delegatingSessions: string[];
@@ -165,6 +176,7 @@ async function buildState(): Promise<DashboardState | { error: string }> {
     const messages = batchGetLastMessages(nonIdleIds);
 
     const allSessionIds = [...sessions, ...archivedSessions].map(s => s.id);
+    const sessionTimings = batchGetSessionTiming(allSessionIds);
     const sessionAgents = batchGetSessionAgents(allSessionIds);
 
     const activeIds = sessions.filter(s => s.status === "ACTIVE").map(s => s.id);
@@ -187,6 +199,7 @@ async function buildState(): Promise<DashboardState | { error: string }> {
       processes,
       transitions,
       sessionTokens,
+      sessionTimings,
       sessionAgents,
       waitingSessions,
       delegatingSessions,
@@ -327,6 +340,49 @@ function buildDemoState(): DashboardState {
     "ses-demo-old-2": "Sisyphus (Ultraworker)",
   };
 
+  const sessionTimings: Record<string, SessionTiming> = {
+    "ses-demo-1": {
+      firstUserRequestAt: now - 2_400_000,
+      lastUserRequestAt: now - 60_000,
+      responseEndAt: now - 3_000,
+    },
+    "ses-demo-2": {
+      firstUserRequestAt: now - 900_000,
+      lastUserRequestAt: now - 30_000,
+      responseEndAt: now - 5_000,
+    },
+    "ses-demo-3": {
+      firstUserRequestAt: now - 1_200_000,
+      lastUserRequestAt: now - 300_000,
+      responseEndAt: now - 120_000,
+    },
+    "ses-demo-4": {
+      firstUserRequestAt: now - 8_400_000,
+      lastUserRequestAt: now - 7_500_000,
+      responseEndAt: now - 7_200_000,
+    },
+    "ses-demo-5": {
+      firstUserRequestAt: now - 420_000,
+      lastUserRequestAt: now - 20_000,
+      responseEndAt: now - 4_000,
+    },
+    "ses-demo-6": {
+      firstUserRequestAt: now - 4_200_000,
+      lastUserRequestAt: now - 600_000,
+      responseEndAt: now - 180_000,
+    },
+    "ses-demo-old-1": {
+      firstUserRequestAt: now - 5 * 86400000 - 900_000,
+      lastUserRequestAt: now - 5 * 86400000 - 600_000,
+      responseEndAt: now - 5 * 86400000 - 300_000,
+    },
+    "ses-demo-old-2": {
+      firstUserRequestAt: now - 7 * 86400000 - 1_200_000,
+      lastUserRequestAt: now - 7 * 86400000 - 900_000,
+      responseEndAt: now - 7 * 86400000 - 600_000,
+    },
+  };
+
   const processes: OcProcess[] = [
     { pid: 42150, cpu: "8.2", mem: "1.8", elapsed: "12:34.56", cwd: "/home/dev/web-app" },
     { pid: 42283, cpu: "5.1", mem: "1.4", elapsed: "08:12.03", cwd: "/home/dev/api-server" },
@@ -343,6 +399,7 @@ function buildDemoState(): DashboardState {
     processes,
     transitions: [],
     sessionTokens,
+    sessionTimings,
     sessionAgents,
     waitingSessions: [],
     delegatingSessions: ["ses-demo-3"],
@@ -370,7 +427,7 @@ setInterval(async () => {
   if (clients.size === 0) return;
   const state = DEMO_MODE ? buildDemoState() : await buildState();
   broadcast(state);
-}, 2_000);
+}, 1_000);
 
 const PORT = parseInt(Bun.env.PORT ?? "3333", 10);
 

--- a/server.ts
+++ b/server.ts
@@ -427,7 +427,7 @@ setInterval(async () => {
   if (clients.size === 0) return;
   const state = DEMO_MODE ? buildDemoState() : await buildState();
   broadcast(state);
-}, 1_000);
+}, 2_000);
 
 const PORT = parseInt(Bun.env.PORT ?? "3333", 10);
 

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -8,6 +8,7 @@ import {
   batchGetSessionTodos,
   batchGetLastMessages,
   batchGetTokenSummary,
+  batchGetSessionTiming,
   getSubAgentCounts,
   getSubAgentSessions,
   getSessionTodos,
@@ -486,5 +487,96 @@ describe("getSubAgentSessions", () => {
     ]);
 
     expect(getSubAgentSessions("parent1")).toHaveLength(0);
+  });
+});
+
+describe("batchGetSessionTiming", () => {
+  test("excludes <system-reminder> user messages and measures last request", () => {
+    const now = Date.now();
+
+    db.run("INSERT INTO message VALUES (?, ?, ?, ?)", [
+      "m-system",
+      "s1",
+      now - 60_000,
+      JSON.stringify({ role: "user", agent: null }),
+    ]);
+    db.run("INSERT INTO part VALUES (?, ?, ?, ?)", [
+      "p-system",
+      "m-system",
+      JSON.stringify({ type: "text", text: "<system-reminder>[ALL BACKGROUND TASKS COMPLETE]" }),
+      now - 60_000,
+    ]);
+
+    db.run("INSERT INTO message VALUES (?, ?, ?, ?)", [
+      "m-user-1",
+      "s1",
+      now - 40_000,
+      JSON.stringify({ role: "user", agent: null }),
+    ]);
+    db.run("INSERT INTO part VALUES (?, ?, ?, ?)", [
+      "p-user-1",
+      "m-user-1",
+      JSON.stringify({ type: "text", text: "Please fix stale sub-agent list" }),
+      now - 40_000,
+    ]);
+
+    db.run("INSERT INTO message VALUES (?, ?, ?, ?)", [
+      "m-user-2",
+      "s1",
+      now - 20_000,
+      JSON.stringify({ role: "user", agent: null }),
+    ]);
+    db.run("INSERT INTO part VALUES (?, ?, ?, ?)", [
+      "p-user-2",
+      "m-user-2",
+      JSON.stringify({ type: "text", text: "Also show timing on session cards" }),
+      now - 20_000,
+    ]);
+
+    db.run("INSERT INTO message VALUES (?, ?, ?, ?)", [
+      "m-assistant-1",
+      "s1",
+      now - 19_000,
+      JSON.stringify({ role: "assistant", agent: "Sisyphus" }),
+    ]);
+    db.run("INSERT INTO part VALUES (?, ?, ?, ?)", [
+      "p-assistant-1",
+      "m-assistant-1",
+      JSON.stringify({ type: "text", text: "Done! Fixed the stale list." }),
+      now - 5_000,
+    ]);
+
+    const result = batchGetSessionTiming(["s1"]);
+    expect(result["s1"]).toBeDefined();
+    expect(result["s1"].firstUserRequestAt).toBe(now - 40_000);
+    expect(result["s1"].lastUserRequestAt).toBe(now - 20_000);
+    expect(result["s1"].responseEndAt).toBe(now - 5_000);
+  });
+
+  test("returns null response time when assistant has not replied yet", () => {
+    const now = Date.now();
+
+    db.run("INSERT INTO message VALUES (?, ?, ?, ?)", [
+      "m-user-only",
+      "s2",
+      now - 15_000,
+      JSON.stringify({ role: "user", agent: null }),
+    ]);
+    db.run("INSERT INTO part VALUES (?, ?, ?, ?)", [
+      "p-user-only",
+      "m-user-only",
+      JSON.stringify({ type: "text", text: "Any update?" }),
+      now - 15_000,
+    ]);
+
+    const result = batchGetSessionTiming(["s2"]);
+    expect(result["s2"]).toBeDefined();
+    expect(result["s2"].firstUserRequestAt).toBe(now - 15_000);
+    expect(result["s2"].lastUserRequestAt).toBe(now - 15_000);
+    expect(result["s2"].responseEndAt).toBeNull();
+  });
+
+  test("returns empty object for empty input", () => {
+    expect(batchGetSessionTiming([])).toEqual({});
   });
 });

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -87,6 +87,11 @@ describeE2E("OC Dashboard v3.1 E2E", () => {
     const statCards = page.locator(".summary-bar .stat-card");
     expect(await statCards.count()).toBeGreaterThanOrEqual(5);
 
+    const allLabels = await page.locator(".summary-bar .stat-label").allTextContents();
+    for (const required of ["Active", "Complete", "Idle", "↑ Input", "↓ Output"]) {
+      expect(allLabels).toContain(required);
+    }
+
     const firstValue = await statCards.nth(0).locator(".stat-value").textContent();
     expect(firstValue).not.toBeNull();
     expect(firstValue!.trim()).toMatch(/^\d+$/);

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -85,7 +85,7 @@ describeE2E("OC Dashboard v3.1 E2E", () => {
   test("3. Summary bar data display", async () => {
     await page.waitForSelector(".summary-bar .stat-card", { timeout: 5000 });
     const statCards = page.locator(".summary-bar .stat-card");
-    expect(await statCards.count()).toBe(5);
+    expect(await statCards.count()).toBeGreaterThanOrEqual(5);
 
     const firstValue = await statCards.nth(0).locator(".stat-value").textContent();
     expect(firstValue).not.toBeNull();


### PR DESCRIPTION
## Summary

- 세션 카드에 **Elapsed / Took** (마지막 요청 처리 시간)과 **Total** (세션 전체 작업 시간) 메트릭 추가
- `<system-reminder>` 메시지를 제외한 실제 사용자 요청 시점 기준으로 타이밍 산출
- SSE 폴링 간격 2s → 1s로 변경하여 실시간 카운터 체감 향상

## Changes

### DB (`db.ts`)
- `SessionTiming` 인터페이스 추가 (`firstUserRequestAt`, `lastUserRequestAt`, `responseEndAt`)
- `batchGetSessionTiming()` — CTE 기반 배치 쿼리: system-reminder 필터링, 응답 완료 시점은 `MAX(part.time_created)` 사용

### Server (`server.ts`)
- `DashboardState`에 `sessionTimings` 필드 추가
- `buildState()` / `buildDemoState()` 에서 타이밍 데이터 생성
- SSE interval 2s → 1s

### Frontend (`public/index.html`)
- `formatDuration()` 헬퍼 추가 (ms → `1m 23s` 형식)
- `renderSessionCard()`에 `timingData` 파라미터 추가
- ACTIVE/WAITING/DELEGATING → `Elapsed` (실시간 틱)
- COMPLETE/IDLE → `Took` (최종 소요 시간)
- `Total` — 첫 사용자 요청 ~ 마지막 활동

### Tests (`tests/db.test.ts`)
- system-reminder 메시지 제외 검증
- assistant 미응답 시 `responseEndAt: null` 검증
- 빈 입력 검증