### PR TITLE
fix: iPad Safari에서 하단 Running Processes 영역 잘림 수정

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>OC Dashboard</title>
   <style>
     :root {
@@ -30,6 +30,7 @@
       grid-template-columns: 240px 1fr;
       grid-template-rows: auto 1fr auto;
       min-height: 100vh;
+      min-height: 100dvh;
       background: var(--bg);
       color: var(--text);
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -204,6 +205,7 @@
       border: 1px solid var(--card-border);
       border-radius: 8px;
       padding: 8px 12px;
+      padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));
       margin-bottom: 0;
       opacity: 0.6;
       font-size: 11px;

--- a/public/index.html
+++ b/public/index.html
@@ -42,7 +42,7 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
-      padding: 12px 16px;
+      padding: calc(12px + env(safe-area-inset-top, 0px)) 16px 12px;
       background: var(--card);
       border-bottom: 1px solid var(--card-border);
     }


### PR DESCRIPTION
Closes #4

## Summary

- `100vh` → `100dvh` fallback 추가 (Safari dynamic viewport height, iOS 15.4+)
- `viewport-fit=cover` 메타태그 추가
- `.process-panel`에 `env(safe-area-inset-bottom)` 패딩 적용
- 데스크톱/Android 등 기존 환경 영향 없음 (미지원 시 기존값 fallback)