### PR TITLE
Linux 플랫폼 지원 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Real-time OpenCode session monitoring dashboard. Bun single-server (TypeScript +
 oc-dashboard/
 ├── server.ts      # HTTP server, SSE broadcast, state aggregation, demo mode
 ├── db.ts          # All SQLite queries — readonly access to OpenCode's DB
-├── process.ts     # macOS-only process detection (ps aux + lsof)
+├── process.ts     # Cross-platform process detection (macOS + Linux)
 ├── plugin/        # OpenCode plugin — writes active-sessions.json on session events
 │   └── index.ts
 ├── public/
@@ -37,7 +37,7 @@ oc-dashboard/
 | Session status logic | `server.ts` → `buildState()` | Merges plugin file + process detection + DB |
 | Status classification | `db.ts` → `classifyStatus()` | ACTIVE <10s, RECENT <5min, IDLE >5min |
 | Plugin behavior | `plugin/index.ts` | Writes `~/.local/share/opencode/active-sessions.json` |
-| Process detection | `process.ts` | macOS-only: `ps aux` → filter `opencode` → `lsof` for cwd |
+| Process detection | `process.ts` | Cross-platform: `ps aux` → filter `opencode` → `/proc/PID/cwd` (Linux) or `lsof` (macOS) |
 | Test setup | `tests/helpers.ts` | `createTestDbFile()` returns tmp DB + cleanup fn |
 | Demo mode | `server.ts` → `buildDemoState()` | `DEMO=true bun run server.ts` for mock data |
 
@@ -50,13 +50,14 @@ oc-dashboard/
 - **Frontend**: No build step, no framework. Raw DOM manipulation. SSE via `EventSource`. All in one HTML file.
 - **Naming**: Files are `kebab-case.ts`. Korean commit messages. Types use `interface` (not `type`).
 - **Tests**: `bun:test` with `describe/test/expect`. DB tests override `process.env.DB_PATH` with temp file.
+- **Platform detection**: `process.platform === "linux"` / `"darwin"` branching in `getCwd()`. Never use `os` module — `process.platform` is sufficient.
 
 ## ANTI-PATTERNS (THIS PROJECT)
 
 - **NEVER** use connection pooling or keep DB handles open — `openDb()` per function is intentional (OpenCode's DB is shared)
 - **NEVER** add frontend build tooling (webpack, vite, etc.) — zero-dependency SPA is a design choice
 - **NEVER** add npm dependencies to root `package.json` unless absolutely unavoidable (playwright is for tests only)
-- **NEVER** assume Linux — process detection uses macOS-specific `lsof -p PID -a -d cwd -Fn`
+- **NEVER** assume specific platform — `getCwd()` branches on `process.platform` (`"linux"` → `/proc`, `"darwin"` → `lsof`)
 - **NEVER** write to OpenCode's DB — all DB access is `readonly: true`
 - **NEVER** use `as any` or `@ts-ignore` — strict mode is enforced
 - **AVOID** splitting `public/index.html` — the single-file approach is deliberate for zero-build deployment

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@
 
 > 이 프로젝트의 모든 코드는 [OpenCode](https://opencode.ai) + [Oh My Open Agent](https://github.com/code-yeongyu/oh-my-openagent)로 구현되었습니다.
 
-> **Note**: 현재 macOS만 지원합니다. 프로세스 감지(`lsof`)가 macOS 전용입니다.
-
 ## Features
 
 | Feature | Description |
@@ -33,7 +31,7 @@
 
 ## Quick Start
 
-**Prerequisites**: macOS · [Bun](https://bun.sh) v1.0+ · [OpenCode](https://opencode.ai)
+**Prerequisites**: macOS / Linux · [Bun](https://bun.sh) v1.0+ · [OpenCode](https://opencode.ai)
 
 ```bash
 # 1. Clone
@@ -63,6 +61,7 @@ bun run server.ts
 
 ```bash
 ipconfig getifaddr en0   # macOS LAN IP 확인
+hostname -I | awk '{print $1}'  # Linux LAN IP 확인
 ```
 
 `http://<LAN_IP>:3333` 접속.

--- a/process.ts
+++ b/process.ts
@@ -7,6 +7,11 @@ export interface OcProcess {
   mem: string;
   elapsed: string;
   cwd: string;
+  isWebServer: boolean;
+}
+
+export function isOpenCodeWebServer(command: string): boolean {
+  return command.includes("opencode web");
 }
 
 export function isMainOpenCodeProcess(command: string): boolean {
@@ -68,8 +73,9 @@ export async function getOpenCodeProcesses(): Promise<OcProcess[]> {
     if (cols.length < 11) continue;
     
     const command = cols.slice(10).join(" ");
+    const webServer = isOpenCodeWebServer(command);
     
-    if (!isMainOpenCodeProcess(command)) continue;
+    if (!webServer && !isMainOpenCodeProcess(command)) continue;
     
     const pid = parseInt(cols[1], 10);
     if (isNaN(pid)) continue;
@@ -79,7 +85,7 @@ export async function getOpenCodeProcesses(): Promise<OcProcess[]> {
     const elapsed = cols[9]; // TIME column
     const cwd = await getCwd(pid);
     
-    processes.push({ pid, cpu, mem, elapsed, cwd });
+    processes.push({ pid, cpu, mem, elapsed, cwd, isWebServer: webServer });
   }
   
   return processes;

--- a/process.ts
+++ b/process.ts
@@ -11,7 +11,9 @@ export interface OcProcess {
 }
 
 export function isOpenCodeWebServer(command: string): boolean {
-  return command.includes("opencode web");
+  const trimmed = command.trim();
+  const bin = trimmed.split(/\s+/)[0];
+  return (bin === "opencode" || bin.endsWith("/opencode")) && trimmed.includes("opencode web");
 }
 
 export function isMainOpenCodeProcess(command: string): boolean {

--- a/process.ts
+++ b/process.ts
@@ -8,7 +8,7 @@ export interface OcProcess {
   cwd: string;
 }
 
-function isMainOpenCodeProcess(command: string): boolean {
+export function isMainOpenCodeProcess(command: string): boolean {
   const trimmed = command.trim();
   
   // Match: "opencode" exactly, or ends with "/opencode", or starts with "opencode "
@@ -29,7 +29,7 @@ function isMainOpenCodeProcess(command: string): boolean {
   return false;
 }
 
-async function getCwd(pid: number): Promise<string> {
+export async function getCwd(pid: number): Promise<string> {
   try {
     // macOS: lsof -p PID -a -d cwd -Fn
     const out = await $`lsof -p ${pid} -a -d cwd -Fn`.text();

--- a/process.ts
+++ b/process.ts
@@ -12,14 +12,8 @@ export interface OcProcess {
 export function isMainOpenCodeProcess(command: string): boolean {
   const trimmed = command.trim();
   
-  // Match: "opencode" exactly, ends with "/opencode", starts with "opencode ", or full path with args
-  if (trimmed === "opencode") return true;
-  if (trimmed.endsWith("/opencode")) return true;
-  if (/^opencode\s+/.test(trimmed)) return true;
-  if (/\/opencode\s+/.test(trimmed)) return true;
-  
-  // Exclude child processes
   if (
+    trimmed.includes("opencode web") ||
     trimmed.includes("pyright") ||
     trimmed.includes("langserver") ||
     trimmed.includes("node") ||
@@ -27,6 +21,11 @@ export function isMainOpenCodeProcess(command: string): boolean {
   ) {
     return false;
   }
+  
+  if (trimmed === "opencode") return true;
+  if (trimmed.endsWith("/opencode")) return true;
+  if (/^opencode\s+/.test(trimmed)) return true;
+  if (/\/opencode\s+/.test(trimmed)) return true;
   
   return false;
 }

--- a/process.ts
+++ b/process.ts
@@ -1,4 +1,5 @@
 import { $ } from "bun";
+import { readlink } from "fs/promises";
 
 export interface OcProcess {
   pid: number;
@@ -30,13 +31,25 @@ export function isMainOpenCodeProcess(command: string): boolean {
 }
 
 export async function getCwd(pid: number): Promise<string> {
-  try {
-    // macOS: lsof -p PID -a -d cwd -Fn
-    const out = await $`lsof -p ${pid} -a -d cwd -Fn`.text();
-    // Output format: "n/path/to/cwd"
-    const match = out.split("\n").find((l) => l.startsWith("n"));
-    return match ? match.slice(1).trim() : "";
-  } catch {
+  if (process.platform === "linux") {
+    try {
+      const cwd = await readlink(`/proc/${pid}/cwd`);
+      return cwd.replace(/ \(deleted\)$/, "");
+    } catch {
+      return "";
+    }
+  } else if (process.platform === "darwin") {
+    try {
+      // macOS: lsof -p PID -a -d cwd -Fn
+      const out = await $`lsof -p ${pid} -a -d cwd -Fn`.text();
+      // Output format: "n/path/to/cwd"
+      const match = out.split("\n").find((l) => l.startsWith("n"));
+      return match ? match.slice(1).trim() : "";
+    } catch {
+      return "";
+    }
+  } else {
+    console.warn("[process] unsupported platform:", process.platform);
     return "";
   }
 }

--- a/process.ts
+++ b/process.ts
@@ -12,10 +12,11 @@ export interface OcProcess {
 export function isMainOpenCodeProcess(command: string): boolean {
   const trimmed = command.trim();
   
-  // Match: "opencode" exactly, or ends with "/opencode", or starts with "opencode "
+  // Match: "opencode" exactly, ends with "/opencode", starts with "opencode ", or full path with args
   if (trimmed === "opencode") return true;
   if (trimmed.endsWith("/opencode")) return true;
   if (/^opencode\s+/.test(trimmed)) return true;
+  if (/\/opencode\s+/.test(trimmed)) return true;
   
   // Exclude child processes
   if (

--- a/public/index.html
+++ b/public/index.html
@@ -913,7 +913,7 @@
       }
       panel.innerHTML = processes.map(p => `
         <span class="process-pill">
-          <span style="color:${p.isWebServer ? 'var(--text-muted)' : 'var(--active)'}">●</span>
+          <span style="color:${p.isWebServer ? '#f778ba' : 'var(--active)'}">●</span>
           ${p.isWebServer ? 'Web Server' : ''} PID ${p.pid} &nbsp; CPU ${p.cpu}% &nbsp; MEM ${p.mem}%
           <span style="color:var(--text-muted)">${escHtml(p.cwd.split('/').pop() || '/')}</span>
         </span>

--- a/public/index.html
+++ b/public/index.html
@@ -913,8 +913,8 @@
       }
       panel.innerHTML = processes.map(p => `
         <span class="process-pill">
-          <span style="color:var(--active)">●</span>
-          PID ${p.pid} &nbsp; CPU ${p.cpu}% &nbsp; MEM ${p.mem}% &nbsp; ${escHtml(p.elapsed)}
+          <span style="color:${p.isWebServer ? 'var(--text-muted)' : 'var(--active)'}">●</span>
+          ${p.isWebServer ? 'Web Server' : ''} PID ${p.pid} &nbsp; CPU ${p.cpu}% &nbsp; MEM ${p.mem}%
           <span style="color:var(--text-muted)">${escHtml(p.cwd.split('/').pop() || '/')}</span>
         </span>
       `).join('');

--- a/server.ts
+++ b/server.ts
@@ -119,7 +119,7 @@ async function buildState(): Promise<DashboardState | { error: string }> {
     if (pluginResult.exists) {
       activeSessionIds = pluginResult.ids;
     } else {
-      const activeCwds = new Set(processes.map(p => p.cwd).filter(Boolean));
+      const activeCwds = new Set(processes.filter(p => !p.isWebServer).map(p => p.cwd).filter(Boolean));
       const newestSessionPerCwd = new Map<string, string>();
       for (const s of rawSessions) {
         if (!activeCwds.has(s.directory)) continue;
@@ -384,9 +384,9 @@ function buildDemoState(): DashboardState {
   };
 
   const processes: OcProcess[] = [
-    { pid: 42150, cpu: "8.2", mem: "1.8", elapsed: "12:34.56", cwd: "/home/dev/web-app" },
-    { pid: 42283, cpu: "5.1", mem: "1.4", elapsed: "08:12.03", cwd: "/home/dev/api-server" },
-    { pid: 42401, cpu: "11.7", mem: "2.1", elapsed: "03:45.21", cwd: "/home/dev/cli-tool" },
+    { pid: 42150, cpu: "8.2", mem: "1.8", elapsed: "12:34.56", cwd: "/home/dev/web-app", isWebServer: false },
+    { pid: 42283, cpu: "5.1", mem: "1.4", elapsed: "08:12.03", cwd: "/home/dev/api-server", isWebServer: false },
+    { pid: 42401, cpu: "11.7", mem: "2.1", elapsed: "03:45.21", cwd: "/home/dev/cli-tool", isWebServer: false },
   ];
 
   return {

--- a/tests/process.test.ts
+++ b/tests/process.test.ts
@@ -25,6 +25,10 @@ describe("isMainOpenCodeProcess", () => {
   test('returns false for "opencode-helper"', () => {
     expect(isMainOpenCodeProcess("opencode-helper")).toBe(false);
   });
+
+  test('returns true for full path with args', () => {
+    expect(isMainOpenCodeProcess("/home/user/.opencode/bin/opencode web --hostname 0.0.0.0")).toBe(true);
+  });
 });
 
 describe("getCwd", () => {

--- a/tests/process.test.ts
+++ b/tests/process.test.ts
@@ -27,7 +27,12 @@ describe("isMainOpenCodeProcess", () => {
   });
 
   test('returns true for full path with args', () => {
-    expect(isMainOpenCodeProcess("/home/user/.opencode/bin/opencode web --hostname 0.0.0.0")).toBe(true);
+    expect(isMainOpenCodeProcess("/home/user/.opencode/bin/opencode --debug")).toBe(true);
+  });
+
+  test('returns false for "opencode web" server process', () => {
+    expect(isMainOpenCodeProcess("/home/user/.opencode/bin/opencode web --hostname 0.0.0.0")).toBe(false);
+    expect(isMainOpenCodeProcess("opencode web --port 4096")).toBe(false);
   });
 });
 

--- a/tests/process.test.ts
+++ b/tests/process.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from "bun:test";
+import { isMainOpenCodeProcess, getCwd, getOpenCodeProcesses } from "../process";
+
+describe("isMainOpenCodeProcess", () => {
+  test('returns true for "opencode"', () => {
+    expect(isMainOpenCodeProcess("opencode")).toBe(true);
+  });
+
+  test('returns true for "/usr/local/bin/opencode"', () => {
+    expect(isMainOpenCodeProcess("/usr/local/bin/opencode")).toBe(true);
+  });
+
+  test('returns true for "opencode --debug"', () => {
+    expect(isMainOpenCodeProcess("opencode --debug")).toBe(true);
+  });
+
+  test('returns false for "node /path/to/pyright"', () => {
+    expect(isMainOpenCodeProcess("node /path/to/pyright")).toBe(false);
+  });
+
+  test('returns false for empty string', () => {
+    expect(isMainOpenCodeProcess("")).toBe(false);
+  });
+
+  test('returns false for "opencode-helper"', () => {
+    expect(isMainOpenCodeProcess("opencode-helper")).toBe(false);
+  });
+});
+
+describe("getCwd", () => {
+  test("returns current working directory for current process", async () => {
+    const result = await getCwd(process.pid);
+    expect(result).toBe(process.cwd());
+  });
+
+  test("returns empty string for non-existent PID", async () => {
+    const result = await getCwd(999999);
+    expect(result).toBe("");
+  });
+});
+
+describe("getOpenCodeProcesses", () => {
+  test("returns array without crashing", async () => {
+    const result = await getOpenCodeProcesses();
+    expect(Array.isArray(result)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `process.ts`의 `getCwd()`에 `process.platform` 분기 추가 (Linux: `/proc/PID/cwd` readlink, macOS: `lsof` 유지)
- `opencode web` 서버 프로세스를 Running Processes에 별도 표시 (분홍색 인디케이터, 세션 감지에서는 제외)
- 풀패스로 실행된 opencode 프로세스 매칭 지원
- README/AGENTS.md에서 macOS-only 문구 제거, Linux 안내 추가
- `tests/process.test.ts` 신규 추가 (유닛 + 통합 테스트)