### PR TITLE
DELEGATING이 표시될 때 WAITING 감지 실패하는 버그 수정

### DIFF
--- a/db.ts
+++ b/db.ts
@@ -407,15 +407,9 @@ export function batchGetPendingQuestions(
         .query<{ session_id: string }, string[]>(
           `SELECT DISTINCT p.session_id
            FROM part p
-           JOIN message m ON p.message_id = m.id
            WHERE p.session_id IN (${placeholders})
              AND json_extract(p.data, '$.tool') = 'question'
-             AND json_extract(p.data, '$.state.status') = 'running'
-             AND m.time_created = (
-               SELECT MAX(m2.time_created)
-               FROM message m2
-               WHERE m2.session_id = p.session_id
-             )`,
+             AND json_extract(p.data, '$.state.status') = 'running'`,
         )
         .all(...sessionIds);
       return new Set(rows.map((r) => r.session_id));


### PR DESCRIPTION
## Summary

- batchGetPendingQuestions 쿼리에서 마지막 메시지 한정 조건(MAX time_created) 제거
- system-reminder 메시지가 끼어들어 question이 마지막 메시지에서 밀려나면 WAITING 감지 실패하는 문제 해결