### PR TITLE
fix: subagent 완료 후 DELEGATING 상태 영구 유지되는 버그 수정

### DIFF
--- a/db.ts
+++ b/db.ts
@@ -429,9 +429,10 @@ export function batchGetPendingBackgroundTasks(
   try {
     const db = openDb();
     try {
+      const now = Date.now();
       const placeholders = sessionIds.map(() => "?").join(",");
       const rows = db
-        .query<{ session_id: string }, string[]>(
+        .query<{ session_id: string }, [...string[], ...string[], ...string[], ...string[], number]>(
           `WITH launched AS (
              SELECT p.session_id,
                substr(json_extract(p.data, '$.state.output'),
@@ -473,9 +474,15 @@ export function batchGetPendingBackgroundTasks(
            FROM launched l
            LEFT JOIN collected c ON l.session_id = c.session_id AND l.bg_id = c.bg_id
            LEFT JOIN cancel_all ca ON l.session_id = ca.session_id
-           WHERE c.bg_id IS NULL AND ca.session_id IS NULL`,
+           WHERE c.bg_id IS NULL AND ca.session_id IS NULL
+             AND EXISTS (
+               SELECT 1 FROM session s
+               WHERE s.parent_id = l.session_id
+                 AND s.time_archived IS NULL
+                 AND ? - s.time_updated < 10000
+             )`,
         )
-        .all(...sessionIds, ...sessionIds, ...sessionIds, ...sessionIds);
+        .all(...sessionIds, ...sessionIds, ...sessionIds, ...sessionIds, now);
       return new Set(rows.map((r) => r.session_id));
     } finally {
       db.close();


### PR DESCRIPTION
## Summary

- `batchGetPendingBackgroundTasks()` 쿼리에 subagent 세션 활성 여부 체크(`EXISTS`) 추가
- 기존: 미수집 background task가 세션 히스토리에 남아있으면 영구 DELEGATING
- 수정: subagent 세션이 종료(RECENT/IDLE)되면 DELEGATING 자동 해제

## Root Cause

기존 쿼리가 `part` 테이블의 bg_id 라이프사이클(launched - collected - cancel_all)만 추적하여, `background_output`으로 수집하지 않은 task가 영구 pending으로 남는 문제. 세션이 새 작업을 시작해도 과거 미수집 task 때문에 DELEGATING이 ACTIVE를 덮어씀.

## Fix

기존 bg_id 추적 로직(비동기 task만 식별) 유지 + `EXISTS (session.parent_id + time_updated < 10s)` 조건 추가로 subagent가 실제 활성 상태인 경우만 DELEGATING 표시.